### PR TITLE
Fix `strtonum` warnings with a libbsd include.

### DIFF
--- a/src/nocsim.h
+++ b/src/nocsim.h
@@ -3,6 +3,7 @@
 
 #ifndef __OpenBSD__
 #define _POSIX_C_SOURCE 2
+#include <bsd/stdlib.h>
 #endif
 
 #include "nocsim_types.h"


### PR DESCRIPTION
This commit includes a `libbsd` header, allowing GCC to resolve the `strtonum` symbol properly.

Also, it makes the `libbsd` dependency more explicit in the source code.